### PR TITLE
Feat/#55

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,4 @@
-ARG JAR_FILE=/home/source/java/build/libs/schoolvery-server-0.0.1-SNAPSHOT.jar
-
-FROM gradle:jdk11 as compile
-WORKDIR /home/source/java
-COPY . .
-RUN chown -R gradle .
-USER gradle
-RUN gradle wrapper
-RUN ./gradlew build
+ARG JAR_FILE=${pwd}/build/libs/schoolvery-server-0.0.1-SNAPSHOT.jar
 
 FROM openjdk:11-jdk
 ARG JAR_FILE
@@ -14,5 +6,5 @@ ARG JAR_FILE
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait
 RUN chmod +x /wait
 
-COPY --from=compile ${JAR_FILE} app.jar
+COPY ${JAR_FILE} app.jar
 CMD /wait && java -jar /app.jar

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 schoolvery-be
 
-## Docker 세팅
+## Docker 실행
+### 사전 세팅
+먼저 ./gradlew build를 통해 jar 파일을 생성합니다.
+해당 파일은 build/libs 안에 schoolvery-server-0.0.1-SNAPSHOT.jar(추후 변경 가능) 라는 이름으로 존재해야 합니다.
 1. .env.example 파일의 이름을 .env로 수정합니다.
 2. 해당 파일에 환경변수를 입력합니다.
 3. `docker-compose up --build`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
       MYSQL_DATABASE: ${DB_DATABASE}
-    ports:
-      - "3306:3306"
     # 현재 db는 개발용이기에 volume 설정 X
 
   adminer: # db 클라이언트
@@ -30,4 +28,7 @@ services:
       - mysql
     environment:
       WAIT_HOSTS: mysql:3306
+      SPRING_DATASOURCE_URL: jdbc:mysql://${DB_HOST}:3306/${DB_DATABASE}
+      SPRING_DATASOURCE_USERNAME: ${DB_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${DB_ROOT_PASSWORD}
     env_file: ./.env

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,20 +4,20 @@ spring.devtools.livereload.enabled=true
 #spring.h2.console.enabled=true
 #spring.h2.console.path=/h2-console
 
-spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+#spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
+#spring.datasource.driverClassName=org.h2.Driver
+#spring.datasource.username=sa
+#spring.datasource.password=
+#spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
 logging.level.org.springframework=debug
 logging.level.org.springframework.web=debug
 
-#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-#spring.datasource.url=jdbc:mysql://${DB_HOST}:3306/${DB_DATABASE}
-#spring.datasource.username=${DB_USERNAME}
-#spring.datasource.password=${DB_ROOT_PASSWORD}
-#spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://${DB_HOST}:3306/${DB_DATABASE}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_ROOT_PASSWORD}
+spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 #spring.jpa.database-platform=org.hibernate.dialect.MySQL5Dialect
 
 spring.jpa.show-sql=true


### PR DESCRIPTION
Dockerfile 수정을 통해 해결

배경:
- ci/cd는 springboot 앱만 진행하면 되는 것이고 db까지 껐다가 띄울 필요는 없다.
- gradle build를 굳이 컨테이너 내부해서 할 필요 없다.(two-stage build 필요 없다)
- 만약 ECS, 쿠버네티스 등으로 띄울 때는 build 서버를 따로 두면 됨

순서:
- 로컬이나 서버 환경에서 먼저 ./gradlew build 진행
- springboot 컨테이너에서는 해당 build로 생성된 jar파일만 copy 해서 run 해줌

굳이 어렵게 생각할 이유가 없었네요 ㅎㅎ!
CI/CD 할 때도 서버측에서 먼저 빌드 해주고 그다음에 docker-compose down & up 해주면 될 것 같습니다.
(이때 db 컨테이너는 그대로 놔두고 springboot 앱만 down & up 해줘도 됨)

이점:
- springboot 앱이 뜨는데 시간 단축
- 컨테이너 안에서 build하면 어쩔 수 없이 생기는https://stackoverflow.com/questions/58593661/slow-gradle-build-in-docker-caching-gradle-build 이러한 고질적인 문제 해결 가능